### PR TITLE
Adding docstring to the greet method of the Greeting interface

### DIFF
--- a/services/greeting.py
+++ b/services/greeting.py
@@ -5,6 +5,8 @@ class Greeting(lymph.Interface):
 
     @lymph.rpc()
     def greet(self, name):
+        """ Returns a greeting for a provided name.
+        """
         print('Saying hi to %s' % name)
         self.emit('greeted', {'name': name})
         return u'Hi, %s!' % name


### PR DESCRIPTION
This would show a nice docstring when you do a lymph inspect.

Maybe this would become confusing, as you won't show the docstring in the slide.
